### PR TITLE
Correctly translate parsing errors to Inequality AST

### DIFF
--- a/src/parseChem.js
+++ b/src/parseChem.js
@@ -23,7 +23,7 @@ export default function(expression = '') {
                     type: 'error',
                     value: token.value,
                     expected: [...new Set(expected)],
-                    loc: (token.line, token.col)
+                    loc: [token.line, token.col]
                 }
             }];
         } else {

--- a/src/parseInequalityChem.js
+++ b/src/parseInequalityChem.js
@@ -222,5 +222,19 @@ function convertToInequality(ast) {
 
 export default function(expression = '') {
     const parsedExpressions = parseChem(expression);
+    if (parsedExpressions.length < 1) return [];
+
+    const firstParse = parsedExpressions.at(0).result;
+    if (firstParse.type === 'error') {
+        // If the first option is not an error a valid parse exists
+        return {
+            error: {
+                offset: firstParse.loc[1] - 1,
+                token: { value: firstParse.value }
+            },
+            message: `Unexpected token ${firstParse.value}`,
+            stack: ""
+        };
+    }
     return parsedExpressions.map(convertToInequality);
 }

--- a/src/parseInequalityNuclear.js
+++ b/src/parseInequalityNuclear.js
@@ -126,5 +126,19 @@ function convertToInequality(ast) {
 
 export default function(expression = '') {
     const parsedExpressions = parseNuclear(expression);
+    if (parsedExpressions.length < 1) return [];
+
+    const firstParse = parsedExpressions.at(0).result;
+    if (firstParse.type === 'error') {
+        // If the first option is not an error a valid parse exists
+        return {
+            error: {
+                offset: firstParse.loc[1] - 1,
+                token: { value: firstParse.value }
+            },
+            message: `Unexpected token ${firstParse.value}`,
+            stack: ""
+        };
+    }
     return parsedExpressions.map(convertToInequality);
 }

--- a/src/parseNuclear.js
+++ b/src/parseNuclear.js
@@ -23,7 +23,7 @@ export default function(expression = '') {
                     type: 'error',
                     value: token.value,
                     expected: [...new Set(expected)],
-                    loc: (token.line, token.col)
+                    loc: [token.line, token.col]
                 }
             }];
         } else {

--- a/src/test/nuclear-parser.test.js
+++ b/src/test/nuclear-parser.test.js
@@ -255,7 +255,7 @@ describe("Parser correctly parses terms", () => {
     it("Returns a 'term' when given prescripts and an isotope",
         () => {
             // Act
-            const tests = ["{}\^{2}_{1}H\^{-}", "{}_{6}\^{13}C", "\^{235}_{92}U", "_{36}\^{92}Kr"];
+            const tests = ["{}\^{2}_{1}H", "{}_{6}\^{13}C", "\^{235}_{92}U", "_{36}\^{92}Kr"];
             const elements = ['H','C','U','Kr'];
             const terms = [];
             tests.forEach(


### PR DESCRIPTION
Previously parsing errors would fall through the conversion causing issues in the front-end. The front-end expects either a bare issue or a list of possible parses hence separating the "error" clause from the switch statement.
