### PR TITLE
Allow number coefficients to be parsed in nuclear

### DIFF
--- a/assets/nuclear-grammar.ne
+++ b/assets/nuclear-grammar.ne
@@ -274,12 +274,12 @@ Particle        -> Prescript %Alpha                             {% processPartic
                  | Prescript %Electron %Negative                {% processElectron %}
 
 # Standardise the order so that `processIsotopeTerm` and `processParticle`s can regex the values out
-Prescript       -> %Mass %Atomic                                    {% function(d) { return d[0].text + d[1].text } %}
-                 | %Atomic %Mass                                    {% function(d) { return d[1].text + d[0].text } %}
-                 | %Nop %Mass %Atomic                               {% function(d) { return d[1].text + d[2].text } %}
-                 | %Nop %Atomic %Mass                               {% function(d) { return d[2].text + d[1].text } %}
+Prescript       -> %Mass %Atomic                                {% function(d) { return d[0].text + d[1].text } %}
+                 | %Atomic %Mass                                {% function(d) { return d[1].text + d[0].text } %}
+                 | %Nop %Mass %Atomic                           {% function(d) { return d[1].text + d[2].text } %}
+                 | %Nop %Atomic %Mass                           {% function(d) { return d[2].text + d[1].text } %}
 
 OptNum          -> null                                         {% function(d) { return 1; } %}
-                 | %Num                                         {% function(d) { return parseInt(d[0].text); } %}
+                 | %Num _                                       {% function(d) { return parseInt(d[0].text); } %}
 
 _               -> %WS:*                                        {% function(d) { return null; } %}


### PR DESCRIPTION
For [questions with plural particles](https://isaacphysics.org/questions/gcse_ch6_54_q1?stage=gcse) (such as `2{}^{1}_{0}\neutron`), the number before the particle was not being recognised due to the `mhchem` formula including an additional space. This adds that space.

(This is just an issue with copying over `OptNum` from Chemistry in which it's used after the element and `OptCoeff` is instead used as here with the `_` space).