### PR TITLE
Allow individual elements to be bracketed, and allow zero-values on input

### DIFF
--- a/assets/chemistry-grammar.ne
+++ b/assets/chemistry-grammar.ne
@@ -15,19 +15,19 @@ const lexer = moo.compile({
     })},
 
     // Charges
-    Charge: { match: /(?:-|\^{(?:[1-9][0-9]*)?(?:\+|-)})/, type: moo.keywords({
+    Charge: { match: /(?:-|\^{(?:[0-9]+)?(?:\+|-)})/, type: moo.keywords({
         Positive: "^{+}",
         Negative: ["^{-}", "-"]
     })},
 
     // Subscripts
-    Sub: /_{[1-9][0-9]*}/,
+    Sub: /_{[0-9]+}/,
 
-    // Non-zero naturals
-    Num: /[1-9][0-9]*/,
+    // Natural numbers
+    Num: /[0-9]+/,
 
     // Fractions
-    Frac: /\\frac{[1-9][0-9]*}{[1-9[0-9]*}/,
+    Frac: /\\frac{[0-9]+}{[0-9]+}/,
     Slash: ['/'],
 
     // State symbols
@@ -38,7 +38,7 @@ const lexer = moo.compile({
     /A[cglmrstu]|B[aehikr]?|C[adeflmnorsu]?|D[bsy]|E[rsu]|F[elmr]?|G[ade]|H[efgos]?|I[nr]?|Kr?|L[airuv]|M[cdgnot]|N[abdehiop]?|O[gs]?|P[abdmortu]?|R[abefghnu]|S[bcegimnr]?|T[abcehilms]|U|V|W|Xe|Yb?|Z[nr]/,
 
     // Hydrate part
-    Water: /\.[\s]*(?:[1-9][0-9]*)?[\s]*H2O/,
+    Water: /\.[\s]*(?:[0-9]+)?[\s]*H2O/,
 
     // Plus symbol
     // (it's hard to subtract chemicals)
@@ -118,7 +118,7 @@ A term is some ion, electron, or hydrate. In this case only the hydrate.
 Processing on the hydrate to extract the value needs to be done.
 */
 const processHydrateTerm = (d) => {
-    const regex = /\.\s*(?<num>[1-9][0-9]*)?\s*H2O/;
+    const regex = /\.\s*(?<num>[0-9]+)?\s*H2O/;
     const matches = d[3].text.match(regex);
 
     return {
@@ -222,7 +222,7 @@ Process an element with subscript.
 An element with a subscript coefficient (such as O_{2}).
 */
 const processElementSub = (d) => {
-    const regex = /_{(?<num>[1-9][0-9]*)}/;
+    const regex = /_{(?<num>[0-9]+)}/;
     const matches = d[1].text.match(regex);
 
     return {
@@ -237,7 +237,7 @@ Process a charge.
 Extract the charge coefficient and sign.
 */
 const processCharge = (d) => {
-    const regex = /\^{(?<value>[1-9][0-9]*)(?<sign>\+|-)}/;
+    const regex = /\^{(?<value>[0-9]+)(?<sign>\+|-)}/;
     const matches = d[0].text.match(regex);
 
     if (matches.groups.sign === '-') {
@@ -267,7 +267,7 @@ Extract the numerator and denominator from the test.
 Return this as a fraction object.
 */
 const processFraction = (d) => {
-    const regex = /\\frac{(?<num>[1-9][0-9]*)}{(?<den>[1-9[0-9]*)}/;
+    const regex = /\\frac{(?<num>[0-9]+)}{(?<den>[0-9]+)}/;
     const match = d[0].text.match(regex);
 
     return {

--- a/assets/chemistry-grammar.ne
+++ b/assets/chemistry-grammar.ne
@@ -348,8 +348,8 @@ RemComp         -> Element                                      {% id %}
                  | Element RemComp                              {% processCompound %}
                  | Bracket RemComp                              {% processCompound %}
 
-Bracket         -> %LParen Compound %RParen OptNum              {% processBracket %}
-                 | %LSquare Compound %RSquare OptNum            {% processBracket %}
+Bracket         -> %LParen Ion %RParen OptNum                   {% processBracket %}
+                 | %LSquare Ion %RSquare OptNum                 {% processBracket %}
 
 Element         -> %Element OptNum                              {% processElement %}
                  | %Element %Sub                                {% processElementSub %}

--- a/assets/nuclear-grammar.ne
+++ b/assets/nuclear-grammar.ne
@@ -12,17 +12,17 @@ const lexer = moo.compile({
     Arrow: "->",
 
     // Mass and Atomic numbers
-    Mass: /\^{(?:[1-9][0-9]*|0)}/,
-    Atomic: /_{(?:-?[1-9][0-9]*|0)}/,
+    Mass: /\^{(?:[0-9]+)}/,
+    Atomic: /_{(?:-?[0-9]+)}/,
 
     // Charges
-    Charge: { match: /(?:-|\^{(?:[1-9][0-9]*)?(?:\+|\-)})/, type: moo.keywords({
+    Charge: { match: /(?:-|\^{(?:[0-9]+)?(?:\+|\-)})/, type: moo.keywords({
         Positive: "^{+}",
         Negative: ["^{-}", "-"]
     })},
 
-    // Non-zero naturals
-    Num: /[1-9][0-9]*/,
+    // Natural numbers
+    Num: /[0-9]+/,
 
     // Chemical Elements
     Element:
@@ -63,7 +63,7 @@ Process prescripts.
 Prescripts are used a lot and are in a standard form
 */
 const getMassAndAtomicNumber = (prescript) => {
-    const regex = /\^{(?<mass>[1-9][0-9]*|0)}_{(?<atomic>-?[1-9][0-9]*|0)}/;
+    const regex = /\^{(?<mass>[0-9]+)}_{(?<atomic>-?[0-9]+)}/;
     // prescript comes from Prescript parser rule so already text
     const matches = prescript.match(regex);
 

--- a/src/parseInequalityChem.js
+++ b/src/parseInequalityChem.js
@@ -14,7 +14,7 @@ function convertCoefficient(coefficient) {
         return undefined;
     }
     if (coefficient.denominator !== 1) {
-        if (coefficient < 1) {
+        if (coefficient < 0) {
             console.error("Negative denominator encounter. Fraction should be normalised!");
             return undefined;
         }
@@ -180,7 +180,7 @@ function convertNode(node) {
                 children: { argument: compound }
             }
 
-            if (node.coeff > 1) {
+            if (node.coeff !== 1) {
                 // Only attach coefficient if it's meaningful
                 bracket.children['subscript'] = {
                     type: 'Num',
@@ -197,7 +197,7 @@ function convertNode(node) {
                 children: {}
             }
 
-            if (node.coeff > 1) {
+            if (node.coeff !== 1) {
                 element.children['subscript'] = {
                     type: 'Num',
                     properties: { significand: node.coeff.toString() },

--- a/src/parseInequalityNuclear.js
+++ b/src/parseInequalityNuclear.js
@@ -41,7 +41,7 @@ function convertNode(node) {
         }
         case 'term': {
             const value = convertNode(node.value);
-            let lhs = node.coeff > 1
+            let lhs = node.coeff !== 1
             ? { type: 'Num', properties: { significand: node.coeff.toString() }, children: { right: value } }
             : value;
 


### PR DESCRIPTION
We want to allow Ions (including ion chains), Compounds, and individual Elements to be bracketed. The type `Ion` covers all of these, so is what we should now check for in bracket parsing.

---

Zero-values have been grammatically disallowed and so lead to syntax errors on input. We already handle them in the Chemistry Checker and so can give better feedback when erroneously used, so they can now be allowed.

Also, certain questions allow a zero-coefficient to specifically show the absence of an element as one of their answers, so this is required for that to be checked.