### PR TITLE
Allow individual Elements and Ions to be hydrated

### DIFF
--- a/assets/chemistry-grammar.ne
+++ b/assets/chemistry-grammar.ne
@@ -329,7 +329,7 @@ Expression      -> Term                                         {% id %}
                  | Term _ %Plus _ Expression                    {% processExpression %}
 
 Term            -> OptCoeff Ion OptState                        {% processTerm %}
-                 | OptCoeff Compound _ %Water OptState          {% processHydrateTerm %}
+                 | OptCoeff Ion _ %Water OptState               {% processHydrateTerm %}
                  | OptCoeff %Electron                           {% processElectronTerm %}
 
 Ion             -> Molecule                                     {% id %}


### PR DESCRIPTION
We want to allow Ions (including ion chains), Compounds, and individual Elements to be hydrated (in the from `_.H2O`).

The type Ion covers all of these, so is what we should now check for in hydrate parsing (much like the recent change to bracket parsing).