### PR TITLE
Allow Nuclear atomic/mass numbers to be omitted

### DIFF
--- a/assets/nuclear-grammar.ne
+++ b/assets/nuclear-grammar.ne
@@ -63,7 +63,7 @@ Process prescripts.
 Prescripts are used a lot and are in a standard form
 */
 const getMassAndAtomicNumber = (prescript) => {
-    const regex = /\^{(?<mass>[0-9]+|())}_{(?<atomic>-?[0-9]+|())}/;
+    const regex = /\^{(?<mass>(?:[0-9]+)?)}_{(?<atomic>(?:-?[0-9]+)?)}/;
     // prescript comes from Prescript parser rule so already text
     const matches = prescript.match(regex);
     

--- a/src/parseInequalityNuclear.js
+++ b/src/parseInequalityNuclear.js
@@ -88,21 +88,26 @@ function convertNode(node) {
                 default: break;
             }
 
+            const children = {}
+            if (node.mass) {
+                children.mass_number = {
+                    type: 'Num',
+                    properties: { significand: node.mass.toString() },
+                    children: {}
+                }
+            }
+            if (node.atomic) {
+                children.proton_number = {
+                    type: 'Num',
+                    properties: { significand: node.atomic.toString() },
+                    children: {}
+                }
+            }
+
             const lhs = {
                 type: 'Particle',
                 properties: { type: particle },
-                children: {
-                    mass_number: {
-                        type: 'Num',
-                        properties: { significand: node.mass.toString() },
-                        children: {}
-                    },
-                    proton_number: {
-                        type: 'Num',
-                        properties: { significand: node.atomic.toString() },
-                        children: {}
-                    }
-                }
+                children: children
             }
 
             if (node.particle === 'positron') {

--- a/src/parseInequalityNuclear.js
+++ b/src/parseInequalityNuclear.js
@@ -48,21 +48,26 @@ function convertNode(node) {
             return lhs;
         }
         case 'isotope': {
+            const children = {}
+            if (node.mass) {
+                children.mass_number = {
+                    type: 'Num',
+                    properties: { significand: node.mass.toString() },
+                    children: {}
+                }
+            }
+            if (node.atomic) {
+                children.proton_number = {
+                    type: 'Num',
+                    properties: { significand: node.atomic.toString() },
+                    children: {}
+                }
+            }
+
             return {
                 type: 'ChemicalElement',
                 properties: { element: node.element },
-                children: {
-                    mass_number: {
-                        type: 'Num',
-                        properties: { significand: node.mass.toString() },
-                        children: {}
-                    },
-                    proton_number: {
-                        type: 'Num',
-                        properties: { significand: node.atomic.toString() },
-                        children: {}
-                    }
-                }
+                children: children
             }
         }
         case 'particle': {

--- a/src/parseInequalityNuclear.js
+++ b/src/parseInequalityNuclear.js
@@ -49,14 +49,14 @@ function convertNode(node) {
         }
         case 'isotope': {
             const children = {}
-            if (node.mass) {
+            if (node.mass !== null) {
                 children.mass_number = {
                     type: 'Num',
                     properties: { significand: node.mass.toString() },
                     children: {}
                 }
             }
-            if (node.atomic) {
+            if (node.atomic !== null) {
                 children.proton_number = {
                     type: 'Num',
                     properties: { significand: node.atomic.toString() },
@@ -89,14 +89,14 @@ function convertNode(node) {
             }
 
             const children = {}
-            if (node.mass) {
+            if (node.mass !== null)  {
                 children.mass_number = {
                     type: 'Num',
                     properties: { significand: node.mass.toString() },
                     children: {}
                 }
             }
-            if (node.atomic) {
+            if (node.atomic !== null)  {
                 children.proton_number = {
                     type: 'Num',
                     properties: { significand: node.atomic.toString() },

--- a/src/test/chemistry-lexer.test.js
+++ b/src/test/chemistry-lexer.test.js
@@ -134,10 +134,10 @@ describe("Lexer correctly identifies 'Charge' symbol", () => {
             expect(neg.value).toBe('\^{19-}');
         }
     );
-    it("Fails to lex '\^{++}', '\^{}', '\^{+', '\^+}', '\^+', '\^{0+}'",
+    it("Fails to lex '\^{++}', '\^{}', '\^{+', '\^+}', '\^+'",
         () => {
             // Act
-            const tests = ['\^{++}', '\^{}', '\^{+', '\^+}', '\^+', '\^{0+}'];
+            const tests = ['\^{++}', '\^{}', '\^{+', '\^+}', '\^+'];
             tests.forEach(
                 function(item, index, arr) {
                     lexer.reset(item);
@@ -167,10 +167,10 @@ describe("Lexer correctly identifies subcripts", () => {
             expect(token.value).toBe('_{20}');
         }
     );
-    it("Fails to lex '_{0}', '_20', '_{}'",
+    it("Fails to lex '_20', '_{}'",
         () => {
             // Act
-            const tests = ['_{0}', '_20', '_{}'];
+            const tests = ['_20', '_{}'];
             const tokens = [];
             tests.forEach(
                 function(item, index, _arr) {

--- a/src/test/chemistry-parser.test.js
+++ b/src/test/chemistry-parser.test.js
@@ -115,7 +115,7 @@ describe("Parser correctly parses brackets", () => {
     it("Returns an 'error' object when brackets are empty or contain elements",
         () => {
             // Act
-            const tests = ['()', '[]', '(C)', '[C]'];
+            const tests = ['()', '[]'];
             const errors = [];
             tests.forEach(
                 function(item, _index, _arr) {
@@ -169,17 +169,17 @@ describe("Parser correctly parses compounds", () => {
             )
         }
     );
-    it("Returns an 'error' object when given a single element",
+    it("Returns an 'term' object when given a single element",
         () => {
             // Act
             // A single element will be parsed as such
             // Brackets must contain
             const AST = parse('[C]')[0];
-            const error = AST.result;
+            const result = AST.result;
 
             // Assert
-            expect(error.type).toBe('error');
-            expect(error.value).toBe(']');
+            expect(result.type).toBe('term');
+            expect(result.value.type).toBe('bracket');
         }
     );
 });

--- a/src/test/nuclear-lexer.test.js
+++ b/src/test/nuclear-lexer.test.js
@@ -124,10 +124,10 @@ describe("Lexer correctly identifies 'Charge' symbol", () => {
             expect(neg.value).toBe('\^{19-}');
         }
     );
-    it("Fails to lex '\^{++}', '\^{}', '\^{+', '\^+}', '\^+', '\^{0+}'",
+    it("Fails to lex '\^{++}', '\^{+', '\^+}', '\^+'",
         () => {
             // Act
-            const tests = ['\^{++}', '\^{}', '\^{+', '\^+}', '\^+', '\^{0+}'];
+            const tests = ['\^{++}', '\^{+', '\^+}', '\^+'];
             tests.forEach(
                 function(item, index, arr) {
                     lexer.reset(item);

--- a/src/test/nuclear-parser.test.js
+++ b/src/test/nuclear-parser.test.js
@@ -1,16 +1,16 @@
 import parse from '../parseNuclear'
 
 describe("Parser captures lexing errors", () => {
-    it("Returns 'error' object when parsing an error",
+    it("Returns 'term' object when parsing an isotope without mass or atomic number",
         () => {
             // Act
             const AST = parse("C")[0];
-            // The first node should be a 'C!' error
-            const error = AST.result;
+            // The first node should be a 'C' term
+            const term = AST.result;
 
             // Assert
-            expect(error.type).toBe('error');
-            expect(error.value).toBe('C');
+            expect(term.type).toBe('term');
+            expect(term.value.element).toBe('C');
         }
     );
 });
@@ -174,14 +174,32 @@ describe("Parser correctly parses particles", () => {
             )
         }
     );
-    it("Returns 'error' when mass and atomic numbers are incorrect or absent",
+    it("Returns 'particle' when mass and atomic numbers are absent",
+        () => {
+            // Act
+            const tests = ['\\alphaparticle', '\\betaparticle', '\\gammaray'];
+            const particles = [];
+            tests.forEach(
+                function(item, _index, _arr) {
+                    const AST = parse(item)[0];
+                    particles.push(AST.result.value)
+                }
+            );
+
+            // Assert
+            particles.forEach(
+                function(item, _index, _arr) {
+                    expect(item.type).toBe('particle');
+                }
+            );
+        }
+    );
+    it("Returns 'error' when mass and atomic numbers are incorrect",
         () => {
             // Act
             const tests = [
-                '\\alphaparticle',
                 '^{0}^{1}\\betaparticle',
                 '_{0}_{1}\\betaparticle',
-                '{}^{4}_{-0}\\alphaparticle',
                 '^{-4}_{2}\\alphaparticle',
             ];
             const errors = []


### PR DESCRIPTION
In mhchem, Nuclear elements are written in the form `{}^{<mass>}_{<atomic>}<element>`.

This grammar already extends mhchem to allow the starting `{}` 'nop' to be omitted and mass/atomic to be entered in whichever order - and in this change also allows for mass/atomic to be omitted. Regardless, it is then converted to standard mhchem form. 

e.g. 
`^{4}\alphaparticle` -> `{}^{4}_{}\alphaparticle`, 
`H` -> `{}^{}_{}H`, 
`_{94}^{}Pu` -> `{}^{}_{94}Pu`

This is used for questions such as [this](https://isaacphysics.org/questions/gcse_ch6_54_q1) which start partially filled, and to allow custom feedback when pre-scripts are missing in a student's answer (rather than the generic syntax error response).

---

Also updates some tests broken by this change or other recent ones (e.g. grammatically allowing 0-values)