### PR TITLE
Render electrons as e^{-} consistently for chemistry questions

### DIFF
--- a/src/parseInequalityChem.js
+++ b/src/parseInequalityChem.js
@@ -79,7 +79,7 @@ function convertNode(node) {
                 const electron = {
                     type: 'Particle',
                     properties: { type: 'electron', particle: '\\electron' },
-                    children: {}
+                    children: { superscript: { type: "BinaryOperation", properties: { operation: "-" } } }
                 }
 
                 if (lhs === undefined) {


### PR DESCRIPTION
Electrons are lexed as `/(?:e|\\electron)(?:\^{-}|-)?/`, so including the - makes no practical difference in the electron term sent to the Chemistry Checker (and indeed the Chemistry checker simply subtracts one from the running charge without checking subscripts) so this will make no difference to the marking of questions.

I will handle releasing this to npm and updating it in the app and checker once this is merged.